### PR TITLE
add logging file, sample slideshows and disable signed grub package

### DIFF
--- a/calamares/branding/blankon/show.qml
+++ b/calamares/branding/blankon/show.qml
@@ -24,7 +24,7 @@ Presentation
     id: presentation
 
     Timer {
-        interval: 20000
+        interval: 15000
         repeat: true
         onTriggered: presentation.goToNextSlide()
     }
@@ -40,8 +40,26 @@ Presentation
         Text {
             anchors.horizontalCenter: background1.horizontalCenter
             anchors.top: background1.bottom
-            text: "Welcome to BlankOn GNU/Linux.<br/>"+
-                  "The rest of the installation is automated and should complete in a few minutes."
+            text: "Selamat datang di BlankOn GNU/Linux.<br/>"+
+                  "Selanjutnya, pemasangan akan dijalankan secara otomatis dan akan selesai dalam beberapa menit lagi."
+            wrapMode: Text.WordWrap
+            width: 600
+            horizontalAlignment: Text.Center
+        }
+    }
+
+    Slide {
+        Image {
+            id: background2
+            source: "slide1.png"
+            width: 467; height: 280
+            fillMode: Image.PreserveAspectFit
+            anchors.centerIn: parent
+        }
+        Text {
+            anchors.horizontalCenter: background2.horizontalCenter
+            anchors.top: background2.bottom
+            text: "Siap untuk memulai kemandirian berperangkat lunak?"
             wrapMode: Text.WordWrap
             width: 600
             horizontalAlignment: Text.Center

--- a/conf/96_calamares-settings-blankon.gschema.override
+++ b/conf/96_calamares-settings-blankon.gschema.override
@@ -1,6 +1,6 @@
 # Launcher icons
 [org.gnome.shell]
-favorite-apps=['install-blankon.desktop', 'firefox-esr.desktop', 'org.gnome.Terminal.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop', 'yelp.desktop']
+favorite-apps=['install-blankon.desktop', 'firefox.desktop', 'org.gnome.Terminal.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop', 'yelp.desktop']
 
 # We don't want the screensaver to enable on the live media while installing
 [org.gnome.desktop.lockdown]

--- a/install-blankon
+++ b/install-blankon
@@ -8,7 +8,7 @@ sudo mv /etc/fstab /etc/fstab.orig.calamares
 
 # Access control to run calamares as root for xwayland
 xhost +si:localuser:root
-pkexec calamares
+pkexec calamares -d > /tmp/calamares-blankon.log
 xhost -si:localuser:root
 
 # Restore stale fstab, for what it's worth

--- a/scripts/bootloader-config
+++ b/scripts/bootloader-config
@@ -14,7 +14,7 @@ echo "Running bootloader-config..."
 
 if [ -d /sys/firmware/efi/efivars ]; then
     echo " * Installing grub-efi (uefi)..."
-    DEBIAN_FRONTEND=noninteractive chroot $CHROOT apt-get -y install grub-efi-amd64 cryptsetup keyutils
+    DEBIAN_FRONTEND=noninteractive chroot $CHROOT apt-get -y install --no-install-recommends efibootmgr grub-efi-amd64 cryptsetup keyutils
 else
     echo " * install grub... (bios)"
     DEBIAN_FRONTEND=noninteractive chroot $CHROOT apt-get -y install grub-pc cryptsetup keyutils


### PR DESCRIPTION
- default log for calamares resides in /root/.cache . Change logging path to /tmp folder for common accessible path. -d option used for enabling debug information
- currently, we only need grub-efi-amd64-bin (and its dependencies) and efibootmgr to use grub2. drop the grub-efi-amd64-signed until we can package it. If we install grub-efi-amd64-signed that signed by debian, the bootloader will stuck again in grub rescue
  ;TLDR disable support for secure boot
- after we click install in summary page, there is slideshow page. I think we can supply sample slides (by now) so user can see what features inside.

to test branding components, see: https://github.com/calamares/calamares-extensions#testing-a-branding-component